### PR TITLE
Add support for fetching UUIDs from macho libs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,9 +34,11 @@ fn generate_macos_bindings() {
         .whitelist_function("_dyld_.*")
         .whitelist_type("mach_header.*")
         .whitelist_type("load_command.*")
+        .whitelist_type("uuid_command.*")
         .whitelist_type("segment_command.*")
         .whitelist_var("MH_MAGIC.*")
         .whitelist_var("LC_SEGMENT.*")
+        .whitelist_var("LC_UUID.*")
         .generate()
         .expect("Should generate macOS FFI bindings OK");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ pub trait SharedLibrary: Sized + Debug {
     fn name(&self) -> &CStr;
 
     /// Get the debug-id of this shared library if available.
-    fn id(&self) -> Option<SharedLibraryId> { None }
+    fn id(&self) -> Option<SharedLibraryId>;
 
     /// Iterate over this shared library's segments.
     fn segments(&self) -> Self::SegmentIter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,40 @@ pub trait Segment: Sized + Debug {
     }
 }
 
+/// Represents an ID for a shared library.
+#[derive(PartialEq, Eq, Hash)]
+pub enum SharedLibraryId {
+    /// A UUID (used on mac)
+    Uuid([u8; 16]),
+}
+
+impl fmt::Display for SharedLibraryId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SharedLibraryId::Uuid(ref bytes) => {
+                for (idx, byte) in bytes.iter().enumerate() {
+                    if idx == 4 || idx == 6 || idx == 8 || idx == 10 {
+                        try!(write!(f, "-"));
+                    }
+                    try!(write!(f, "{:02x}", byte));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for SharedLibraryId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SharedLibraryId::Uuid(..) => {
+                write!(f, "Uuid(\"{}\")", self)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 /// A trait representing a shared library that is loaded in this process.
 pub trait SharedLibrary: Sized + Debug {
     /// The associated segment type for this shared library.
@@ -235,6 +269,9 @@ pub trait SharedLibrary: Sized + Debug {
 
     /// Get the name of this shared library.
     fn name(&self) -> &CStr;
+
+    /// Get the debug-id of this shared library if available.
+    fn id(&self) -> Option<SharedLibraryId> { None }
 
     /// Iterate over this shared library's segments.
     fn segments(&self) -> Self::SegmentIter;

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -55,10 +55,6 @@ impl<'a> SegmentTrait for Segment<'a> {
         }
     }
 
-    fn id(&self) -> Option<SharedLibraryId> {
-        None
-    }
-
     #[inline]
     fn stated_virtual_memory_address(&self) -> Svma {
         Svma(unsafe {
@@ -151,6 +147,11 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
     #[inline]
     fn name(&self) -> &CStr {
         self.name
+    }
+
+    #[inline]
+    fn id(&self) -> Option<SharedLibraryId> {
+        None
     }
 
     #[inline]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,6 +1,6 @@
 //! Linux-specific implementation of the `SharedLibrary` trait.
 
-use super::{Bias, IterationControl, Svma};
+use super::{Bias, IterationControl, Svma, SharedLibraryId};
 use super::Segment as SegmentTrait;
 use super::SharedLibrary as SharedLibraryTrait;
 
@@ -53,6 +53,10 @@ impl<'a> SegmentTrait for Segment<'a> {
                 _ => CStr::from_ptr("(unknown segment type)\0".as_ptr() as _),
             }
         }
+    }
+
+    fn id(&self) -> Option<SharedLibraryId> {
+        None
     }
 
     #[inline]

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -141,7 +141,8 @@ impl<'a> MachHeader<'a> {
         MachType::from_header_ptr(header).and_then(|ty| {
             match ty {
                 MachType::Mach32 => header.as_ref().map(MachHeader::Header32),
-                MachType::Mach64 => (header as *const _).as_ref().map(MachHeader::Header64),
+                MachType::Mach64 => (header as *const bindings::mach_header_64)
+                    .as_ref().map(MachHeader::Header64),
             }
         })
     }


### PR DESCRIPTION
We actually only ever use the UUID for symbolication but the library so far does not expose it. I made this generic so that later build notes from Elf can also be supported. It also does not add a dependency to the UUID crate but instead just exposes a `[u8; 16]`.