### PR TITLE
Section support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0/MIT"
 name = "findshlibs"
 readme = "./README.md"
 repository = "https://github.com/gimli-rs/findshlibs"
-version = "0.4.0"
+version = "0.4.1"
 
 [badges.coveralls]
 repository = "gimli-rs/findshlibs"

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,7 @@ fn generate_macos_bindings() {
         .whitelist_type("load_command.*")
         .whitelist_type("uuid_command.*")
         .whitelist_type("segment_command.*")
+        .whitelist_type("section.*")
         .whitelist_var("MH_MAGIC.*")
         .whitelist_var("LC_SEGMENT.*")
         .whitelist_var("LC_UUID.*")

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -2,12 +2,33 @@
 //! trait](../trait.SharedLibrary.html) that does nothing.
 
 use super::Segment as SegmentTrait;
+use super::Section as SectionTrait;
 use super::SharedLibrary as SharedLibraryTrait;
 use super::{Bias, IterationControl, SharedLibraryId, Svma};
 
 use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::usize;
+
+/// An unsupported command
+#[derive(Debug)]
+pub struct Section<'a> {
+    phantom: PhantomData<&'a SharedLibrary<'a>>,
+}
+
+impl<'a> SectionTrait for Section<'a> {
+    fn name(&self) -> &CStr {
+        unimplemented!()
+    }
+
+    fn stated_virtual_memory_address(&self) -> Svma {
+        unimplemented!()
+    }
+
+    fn len(&self) -> usize {
+        unimplemented!()
+    }
+}
 
 /// An unsupported segment
 #[derive(Debug)]
@@ -17,6 +38,12 @@ pub struct Segment<'a> {
 
 impl<'a> SegmentTrait for Segment<'a> {
     type SharedLibrary = ::unsupported::SharedLibrary<'a>;
+    type Section = ::unsupported::Section<'a>;
+    type SectionIter = ::unsupported::SectionIter<'a>;
+
+    fn sections(&self) -> SectionIter<'a> {
+        unimplemented!()
+    }
 
     #[inline]
     fn name(&self) -> &CStr {
@@ -31,6 +58,20 @@ impl<'a> SegmentTrait for Segment<'a> {
     #[inline]
     fn len(&self) -> usize {
         unreachable!()
+    }
+}
+
+/// A no-op iterator over commands.
+#[derive(Debug)]
+pub struct SectionIter<'a> {
+    phantom: PhantomData<&'a SharedLibrary<'a>>,
+}
+
+impl<'a> Iterator for SectionIter<'a> {
+    type Item = ::unsupported::Section<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
     }
 }
 


### PR DESCRIPTION
Ah shoot, have just spotted you have a section branch already in the repo.

I'm going to PR anyway as it looks like we've taken different routes - I've not tied it in to what any sections mean. I.e. no refs to EhFrame / EhFrameHdr. To me it feels like what the sections are / do should be handled by some higher crate. 

Todo: Linux impl of section - once I figure out how to cross compile :-) .

Have a look - see which you prefer / alt we can take bits from both. I just need section support somehow for use with the unwind crate. I don't care how / who.