### PR TITLE
Use libc for `libdl` bindings on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,16 @@ repository = "gimli-rs/findshlibs"
 [badges.travis-ci]
 repository = "gimli-rs/findshlibs"
 
-[build-dependencies.bindgen]
-default-features = false
-version = "0.38.0"
+[build-dependencies]
+cfg-if = "0.1.2"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+bindgen = { version = "0.39.0", default-features = false }
 
 [dependencies]
 cfg-if = "0.1.2"
 lazy_static = "1.0.0"
+libc = "0.2.43"
 
 [features]
 nightly = []

--- a/build.rs
+++ b/build.rs
@@ -1,47 +1,37 @@
-extern crate bindgen;
+#[macro_use]
+extern crate cfg_if;
 
-use std::env;
-use std::path::PathBuf;
+cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        extern crate bindgen;
 
-fn main() {
-    if cfg!(target_os = "linux") {
-        generate_linux_bindings();
-    } else if cfg!(target_os = "macos") {
-        generate_macos_bindings();
+        use std::env;
+        use std::path::PathBuf;
+
+        fn main() {
+            generate_macos_bindings();
+        }
+
+        fn generate_macos_bindings() {
+            let bindings = bindgen::Builder::default()
+                .header("./src/macos/bindings.h")
+                .whitelist_function("_dyld_.*")
+                .whitelist_type("mach_header.*")
+                .whitelist_type("load_command.*")
+                .whitelist_type("uuid_command.*")
+                .whitelist_type("segment_command.*")
+                .whitelist_var("MH_MAGIC.*")
+                .whitelist_var("LC_SEGMENT.*")
+                .whitelist_var("LC_UUID.*")
+                .generate()
+                .expect("Should generate macOS FFI bindings OK");
+
+            let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+            bindings
+                .write_to_file(out_path.join("macos_bindings.rs"))
+                .expect("Should write macos_bindings.rs OK");
+        }
+    } else {
+        fn main() {}
     }
-}
-
-fn generate_linux_bindings() {
-    let bindings = bindgen::Builder::default()
-        .header("./src/linux/bindings.h")
-        .whitelist_function("dl_iterate_phdr")
-        .whitelist_type(r#"Elf\d*.*"#)
-        .whitelist_var("PT_.*")
-        .generate()
-        .expect("Should generate linux FFI bindings OK");
-
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("linux_bindings.rs"))
-        .expect("Should write linux_bindings.rs OK");
-}
-
-fn generate_macos_bindings() {
-    let bindings = bindgen::Builder::default()
-        .header("./src/macos/bindings.h")
-        .whitelist_function("_dyld_.*")
-        .whitelist_type("mach_header.*")
-        .whitelist_type("load_command.*")
-        .whitelist_type("uuid_command.*")
-        .whitelist_type("segment_command.*")
-        .whitelist_var("MH_MAGIC.*")
-        .whitelist_var("LC_SEGMENT.*")
-        .whitelist_var("LC_UUID.*")
-        .generate()
-        .expect("Should generate macOS FFI bindings OK");
-
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("macos_bindings.rs"))
-        .expect("Should write macos_bindings.rs OK");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@ extern crate cfg_if;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(target_os = "linux")]
+extern crate libc;
+
 use std::ffi::CStr;
 use std::fmt::{self, Debug};
 use std::ptr;

--- a/src/linux/bindings.h
+++ b/src/linux/bindings.h
@@ -1,2 +1,0 @@
-#define _GNU_SOURCE
-#include <link.h>

--- a/src/linux/bindings.rs
+++ b/src/linux/bindings.rs
@@ -1,5 +1,0 @@
-#![allow(non_snake_case)]
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
-
-include!(concat!(env!("OUT_DIR"), "/linux_bindings.rs"));

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -6,19 +6,19 @@ use super::SharedLibrary as SharedLibraryTrait;
 
 use std::any::Any;
 use std::ffi::CStr;
+use std::fmt;
 use std::isize;
 use std::marker::PhantomData;
-use std::os::raw;
 use std::panic;
 use std::slice;
 
-mod bindings;
+use libc;
 
 cfg_if! {
     if #[cfg(target_pointer_width = "32")] {
-        type Phdr = bindings::Elf32_Phdr;
+        type Phdr = libc::Elf32_Phdr;
     } else if #[cfg(target_pointer_width = "64")] {
-        type Phdr = bindings::Elf64_Phdr;
+        type Phdr = libc::Elf64_Phdr;
     } else {
         // Unsupported.
     }
@@ -37,19 +37,19 @@ impl<'a> SegmentTrait for Segment<'a> {
     fn name(&self) -> &CStr {
         unsafe {
             match self.phdr.as_ref().unwrap().p_type {
-                bindings::PT_NULL => CStr::from_ptr("NULL\0".as_ptr() as _),
-                bindings::PT_LOAD => CStr::from_ptr("LOAD\0".as_ptr() as _),
-                bindings::PT_DYNAMIC => CStr::from_ptr("DYNAMIC\0".as_ptr() as _),
-                bindings::PT_INTERP => CStr::from_ptr("INTERP\0".as_ptr() as _),
-                bindings::PT_NOTE => CStr::from_ptr("NOTE\0".as_ptr() as _),
-                bindings::PT_SHLIB => CStr::from_ptr("SHLI\0".as_ptr() as _),
-                bindings::PT_PHDR => CStr::from_ptr("PHDR\0".as_ptr() as _),
-                bindings::PT_TLS => CStr::from_ptr("TLS\0".as_ptr() as _),
-                bindings::PT_NUM => CStr::from_ptr("NUM\0".as_ptr() as _),
-                bindings::PT_LOOS => CStr::from_ptr("LOOS\0".as_ptr() as _),
-                bindings::PT_GNU_EH_FRAME => CStr::from_ptr("GNU_EH_FRAME\0".as_ptr() as _),
-                bindings::PT_GNU_STACK => CStr::from_ptr("GNU_STACK\0".as_ptr() as _),
-                bindings::PT_GNU_RELRO => CStr::from_ptr("GNU_RELRO\0".as_ptr() as _),
+                libc::PT_NULL => CStr::from_ptr("NULL\0".as_ptr() as _),
+                libc::PT_LOAD => CStr::from_ptr("LOAD\0".as_ptr() as _),
+                libc::PT_DYNAMIC => CStr::from_ptr("DYNAMIC\0".as_ptr() as _),
+                libc::PT_INTERP => CStr::from_ptr("INTERP\0".as_ptr() as _),
+                libc::PT_NOTE => CStr::from_ptr("NOTE\0".as_ptr() as _),
+                libc::PT_SHLIB => CStr::from_ptr("SHLI\0".as_ptr() as _),
+                libc::PT_PHDR => CStr::from_ptr("PHDR\0".as_ptr() as _),
+                libc::PT_TLS => CStr::from_ptr("TLS\0".as_ptr() as _),
+                libc::PT_NUM => CStr::from_ptr("NUM\0".as_ptr() as _),
+                libc::PT_LOOS => CStr::from_ptr("LOOS\0".as_ptr() as _),
+                libc::PT_GNU_EH_FRAME => CStr::from_ptr("GNU_EH_FRAME\0".as_ptr() as _),
+                libc::PT_GNU_STACK => CStr::from_ptr("GNU_STACK\0".as_ptr() as _),
+                libc::PT_GNU_RELRO => CStr::from_ptr("GNU_RELRO\0".as_ptr() as _),
                 _ => CStr::from_ptr("(unknown segment type)\0".as_ptr() as _),
             }
         }
@@ -71,7 +71,6 @@ impl<'a> SegmentTrait for Segment<'a> {
 }
 
 /// An iterator of mapped segments in a shared library.
-#[derive(Debug)]
 pub struct SegmentIter<'a> {
     inner: ::std::slice::Iter<'a, Phdr>,
 }
@@ -88,8 +87,18 @@ impl<'a> Iterator for SegmentIter<'a> {
     }
 }
 
+impl<'a> fmt::Debug for SegmentIter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ref phdr = self.inner.as_slice()[0];
+
+        write!(f, "SegmentIter {{ phdr: ")?;
+        fmt_debug_phdr(phdr, f)?;
+        write!(f, " }}")
+    }
+}
+
 /// A shared library on Linux.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct SharedLibrary<'a> {
     size: usize,
     addr: *const u8,
@@ -102,11 +111,11 @@ struct IterState<F> {
     panic: Option<Box<Any + Send>>,
 }
 
-const CONTINUE: raw::c_int = 0;
-const BREAK: raw::c_int = 1;
+const CONTINUE: libc::c_int = 0;
+const BREAK: libc::c_int = 1;
 
 impl<'a> SharedLibrary<'a> {
-    unsafe fn new(info: &'a bindings::dl_phdr_info, size: usize) -> Self {
+    unsafe fn new(info: &'a libc::dl_phdr_info, size: usize) -> Self {
         SharedLibrary {
             size: size,
             addr: info.dlpi_addr as usize as *const _,
@@ -115,10 +124,10 @@ impl<'a> SharedLibrary<'a> {
         }
     }
 
-    unsafe extern "C" fn callback<F, C>(info: *mut bindings::dl_phdr_info,
+    unsafe extern "C" fn callback<F, C>(info: *mut libc::dl_phdr_info,
                                         size: usize,
-                                        state: *mut raw::c_void)
-                                        -> raw::c_int
+                                        state: *mut libc::c_void)
+                                        -> libc::c_int
         where F: FnMut(&Self) -> C,
               C: Into<IterationControl>
     {
@@ -176,13 +185,41 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
         };
 
         unsafe {
-            bindings::dl_iterate_phdr(Some(Self::callback::<F, C>), &mut state as *mut _ as *mut _);
+            libc::dl_iterate_phdr(Some(Self::callback::<F, C>), &mut state as *mut _ as *mut _);
         }
 
         if let Some(panic) = state.panic {
             panic::resume_unwind(panic);
         }
     }
+}
+
+impl<'a> fmt::Debug for SharedLibrary<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SharedLibrary {{ size: {:?}, addr: {:?}, ", self.size, self.addr)?;
+        write!(f, "name: {:?}, headers: [",  self.name)?;
+
+        // Debug does not usually have a trailing comma in the list,
+        // last element must be formatted separately.
+        let l = self.headers.len();
+        self.headers[..(l - 1)].into_iter()
+            .map(|phdr| fmt_debug_phdr(phdr, f).and_then(|_| write!(f, ", ")))
+            .collect::<fmt::Result>()?;
+
+        fmt_debug_phdr(&self.headers[l - 1], f)?;
+
+        write!(f, "] }}")
+    }
+}
+
+// Helper function for implementing Debug for structures which contain Phdr.
+fn fmt_debug_phdr(phdr: &Phdr, f: &mut fmt::Formatter) -> fmt::Result {
+    // The layout is different for 32-bit vs 64-bit, but since the fields are the same,
+    // it shouldn't matter much.
+    write!(f, "Phdr {{ p_type: {:#X}, p_flags: {:?}, ", phdr.p_type, phdr.p_flags)?;
+    write!(f, "p_offset: {:#X}, p_vaddr: {:#X}, ", phdr.p_offset, phdr.p_vaddr)?;
+    write!(f, "p_paddr: {:#X}, p_filesz: {:?}, ", phdr.p_paddr, phdr.p_filesz)?;
+    write!(f, "p_memsz: {:?}, p_align: {:#X} }}", phdr.p_memsz, phdr.p_align)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Since we don't need a lot of stuff from `link.h`, I think it's better to drop bindgen and manually define the things we need from the header.

Note: a similar thing could be done for MacOS, so we can drop bindgen there too. I don't have a Mac device to develop on however.