### PR TITLE
Added is_code to detect code segments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,10 @@ pub trait Segment: Sized + Debug {
     /// Get this segment's name.
     fn name(&self) -> &CStr;
 
+    /// Returns `true` if this is a code segment.
+    #[inline]
+    fn is_code(&self) -> bool { false }
+
     /// Get this segment's stated virtual address of this segment.
     ///
     /// This is the virtual memory address without the bias applied. See the

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -59,11 +59,13 @@ impl<'a> SegmentTrait for Segment<'a> {
 
     #[inline]
     fn is_code(&self) -> bool {
-        let hdr = self.phdr.as_ref().unwrap();
-        match hdr.p_type {
-            // 0x1 is PT_X for executable
-            libc::PT_LOAD => (hdr.p_flags & 0x1) != 0,
-            _ => false,
+        unsafe {
+            let hdr = self.phdr.as_ref().unwrap();
+            match hdr.p_type {
+                // 0x1 is PT_X for executable
+                libc::PT_LOAD => (hdr.p_flags & 0x1) != 0,
+                _ => false,
+            }
         }
     }
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -14,6 +14,8 @@ use std::slice;
 
 use libc;
 
+
+
 cfg_if! {
     if #[cfg(target_pointer_width = "32")] {
         type Phdr = libc::Elf32_Phdr;
@@ -52,6 +54,16 @@ impl<'a> SegmentTrait for Segment<'a> {
                 libc::PT_GNU_RELRO => CStr::from_ptr("GNU_RELRO\0".as_ptr() as _),
                 _ => CStr::from_ptr("(unknown segment type)\0".as_ptr() as _),
             }
+        }
+    }
+
+    #[inline]
+    fn is_code(&self) -> bool {
+        let hdr = self.phdr.as_ref().unwrap();
+        match hdr.p_type {
+            // 0x1 is PT_X for executable
+            libc::PT_LOAD => (hdr.p_flags & 0x1) != 0,
+            _ => false,
         }
     }
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -14,8 +14,6 @@ use std::slice;
 
 use libc;
 
-
-
 cfg_if! {
     if #[cfg(target_pointer_width = "32")] {
         type Phdr = libc::Elf32_Phdr;

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -44,6 +44,11 @@ impl<'a> SegmentTrait for Segment<'a> {
     }
 
     #[inline]
+    fn is_code(&self) -> bool {
+        self.name().to_bytes() == b"__TEXT"
+    }
+
+    #[inline]
     fn stated_virtual_memory_address(&self) -> Svma {
         match *self {
             Segment::Segment32(seg) => Svma(seg.vmaddr as usize as *const u8),


### PR DESCRIPTION
This adds an `is_code` method to detect code segments. This is useful for enabling server side symbolication with sentry on musl targets for instance: https://github.com/getsentry/sentry-rust/pull/112