### PR TITLE
Make clippy happy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ simple_newtypes! {
 }
 
 /// A mapped segment in a shared library.
+#[allow(clippy::len_without_is_empty)]
 pub trait Segment: Sized + Debug {
     /// The associated shared library type for this segment.
     type SharedLibrary: SharedLibrary<Segment = Self>;
@@ -206,7 +207,9 @@ pub trait Segment: Sized + Debug {
 
     /// Returns `true` if this is a code segment.
     #[inline]
-    fn is_code(&self) -> bool { false }
+    fn is_code(&self) -> bool {
+        false
+    }
 
     /// Get this segment's stated virtual address of this segment.
     ///

--- a/src/macos/bindings.rs
+++ b/src/macos/bindings.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
+#![allow(clippy::unreadable_literal)]
 
 include!(concat!(env!("OUT_DIR"), "/macos_bindings.rs"));

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -1,5 +1,6 @@
 //! The MacOS implementation of the [SharedLibrary
 //! trait](../trait.SharedLibrary.html).
+#![allow(clippy::cast_ptr_alignment)]
 
 use super::{Bias, IterationControl, Svma, SharedLibraryId};
 use super::Segment as SegmentTrait;
@@ -7,7 +8,6 @@ use super::SharedLibrary as SharedLibraryTrait;
 
 use std::ffi::CStr;
 use std::marker::PhantomData;
-use std::ptr;
 use std::sync::Mutex;
 use std::usize;
 
@@ -259,7 +259,7 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
             if let Some(header) = unsafe { MachHeader::from_header_ptr(header) } {
                 assert!(slide != 0,
                         "If we have a header pointer, slide should be valid");
-                assert!(name != ptr::null(),
+                assert!(!name.is_null(),
                         "If we have a header pointer, name should be valid");
 
                 let name = unsafe { CStr::from_ptr(name) };
@@ -286,8 +286,7 @@ mod tests {
             found_dyld |= shlib.name
                 .to_bytes()
                 .split(|c| *c == b'.' || *c == b'/')
-                .find(|s| s == b"libdyld")
-                .is_some();
+                .any(|s| s == b"libdyld");
         });
         assert!(found_dyld);
     }


### PR DESCRIPTION
I started doing some changes to the library and noticed that my editor gives me plenty of clippy warnings and it also did not entirely pass cargo fmt.

This PR just cleans it up slightly to be more consistent and silences all clippy warnings that are bogus.