### PR TITLE
Implement id() and improve name() for ELF

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,14 +1,18 @@
 //! Linux-specific implementation of the `SharedLibrary` trait.
 
-use super::{Bias, IterationControl, Svma, SharedLibraryId};
 use super::Segment as SegmentTrait;
 use super::SharedLibrary as SharedLibraryTrait;
+use super::{Bias, IterationControl, SharedLibraryId, Svma};
 
 use std::any::Any;
-use std::ffi::CStr;
+use std::borrow::Cow;
+use std::env::current_exe;
+use std::ffi::{CStr, CString};
 use std::fmt;
 use std::isize;
 use std::marker::PhantomData;
+use std::mem;
+use std::os::unix::ffi::OsStringExt;
 use std::panic;
 use std::slice;
 
@@ -22,6 +26,14 @@ cfg_if! {
     } else {
         // Unsupported.
     }
+}
+
+const NT_GNU_BUILD_ID: u32 = 3;
+
+struct Nhdr32 {
+    pub n_namesz: libc::Elf32_Word,
+    pub n_descsz: libc::Elf32_Word,
+    pub n_type: libc::Elf32_Word,
 }
 
 /// A mapped segment in an ELF file.
@@ -69,16 +81,12 @@ impl<'a> SegmentTrait for Segment<'a> {
 
     #[inline]
     fn stated_virtual_memory_address(&self) -> Svma {
-        Svma(unsafe {
-            (*self.phdr).p_vaddr as _
-        })
+        Svma(unsafe { (*self.phdr).p_vaddr as _ })
     }
 
     #[inline]
     fn len(&self) -> usize {
-        unsafe {
-            (*self.phdr).p_memsz as _
-        }
+        unsafe { (*self.phdr).p_memsz as _ }
     }
 }
 
@@ -94,7 +102,7 @@ impl<'a> Iterator for SegmentIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|phdr| Segment {
             phdr: phdr,
-            shlib: PhantomData
+            shlib: PhantomData,
         })
     }
 }
@@ -103,49 +111,79 @@ impl<'a> fmt::Debug for SegmentIter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ref phdr = self.inner.as_slice()[0];
 
-        f.debug_struct("SegmentIter").field("phdr", &DebugPhdr(phdr)).finish()
+        f.debug_struct("SegmentIter")
+            .field("phdr", &DebugPhdr(phdr))
+            .finish()
     }
 }
 
 /// A shared library on Linux.
-#[derive(Clone, Copy)]
 pub struct SharedLibrary<'a> {
     size: usize,
     addr: *const u8,
-    name: &'a CStr,
+    name: Cow<'a, CStr>,
     headers: &'a [Phdr],
 }
 
 struct IterState<F> {
     f: F,
     panic: Option<Box<Any + Send>>,
+    idx: usize,
 }
 
 const CONTINUE: libc::c_int = 0;
 const BREAK: libc::c_int = 1;
 
 impl<'a> SharedLibrary<'a> {
-    unsafe fn new(info: &'a libc::dl_phdr_info, size: usize) -> Self {
+    unsafe fn new(info: &'a libc::dl_phdr_info, size: usize, is_first_lib: bool) -> Self {
+        // try to get the name from the dl_phdr_info.  If that fails there are two
+        // cases we can and need to deal with.  The first one is if we are the first
+        // loaded library in which case the name is the executable which we can
+        // discover via env::current_exe (reads the proc/self symlink).
+        //
+        // Otherwise if we have a no name we might be a dylib that was loaded with
+        // dlopen in which case we can use dladdr to recover the name.
+        let mut name = Cow::Borrowed(if info.dlpi_name.is_null() {
+            CStr::from_bytes_with_nul_unchecked(b"\0")
+        } else {
+            CStr::from_ptr(info.dlpi_name)
+        });
+        if name.to_bytes().is_empty() {
+            if is_first_lib {
+                if let Ok(exe) = current_exe() {
+                    name = Cow::Owned(CString::from_vec_unchecked(exe.into_os_string().into_vec()));
+                }
+            } else {
+                let mut dlinfo: libc::Dl_info = mem::zeroed();
+                if libc::dladdr(info.dlpi_addr as *const libc::c_void, &mut dlinfo) != 0 {
+                    name = Cow::Owned(CString::from(CStr::from_ptr(dlinfo.dli_fname)));
+                }
+            }
+        }
+
         SharedLibrary {
             size: size,
             addr: info.dlpi_addr as usize as *const _,
-            name: CStr::from_ptr(info.dlpi_name),
+            name,
             headers: slice::from_raw_parts(info.dlpi_phdr, info.dlpi_phnum as usize),
         }
     }
 
-    unsafe extern "C" fn callback<F, C>(info: *mut libc::dl_phdr_info,
-                                        size: usize,
-                                        state: *mut libc::c_void)
-                                        -> libc::c_int
-        where F: FnMut(&Self) -> C,
-              C: Into<IterationControl>
+    unsafe extern "C" fn callback<F, C>(
+        info: *mut libc::dl_phdr_info,
+        size: usize,
+        state: *mut libc::c_void,
+    ) -> libc::c_int
+    where
+        F: FnMut(&Self) -> C,
+        C: Into<IterationControl>,
     {
         let state = &mut *(state as *mut IterState<F>);
+        state.idx += 1;
 
         match panic::catch_unwind(panic::AssertUnwindSafe(|| {
             let info = info.as_ref().unwrap();
-            let shlib = SharedLibrary::new(info, size);
+            let shlib = SharedLibrary::new(info, size, state.idx == 1);
 
             (state.f)(&shlib).into()
         })) {
@@ -165,17 +203,62 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
 
     #[inline]
     fn name(&self) -> &CStr {
-        self.name
+        &*self.name
     }
 
-    #[inline]
     fn id(&self) -> Option<SharedLibraryId> {
+        fn align(alignment: usize, offset: &mut usize) {
+            let diff = *offset % alignment;
+            if diff != 0 {
+                *offset += alignment - diff;
+            }
+        }
+
+        unsafe {
+            for segment in self.segments() {
+                let phdr = segment.phdr.as_ref().unwrap();
+                if phdr.p_type != libc::PT_NOTE {
+                    continue;
+                }
+
+                let mut alignment = phdr.p_align as usize;
+                // same logic as in gimli which took it from readelf
+                if alignment < 4 {
+                    alignment = 4;
+                } else if alignment != 4 && alignment != 8 {
+                    continue;
+                }
+
+                let mut offset = phdr.p_offset as usize;
+                let end = offset + phdr.p_filesz as usize;
+
+                while offset < end {
+                    // we always use an nhdr32 here as 64bit notes have not
+                    // been observed in practice.
+                    let nhdr = &*((self.addr as usize + offset) as *const Nhdr32);
+                    offset += mem::size_of_val(nhdr);
+                    offset += nhdr.n_namesz as usize;
+                    align(alignment, &mut offset);
+                    let value =
+                        slice::from_raw_parts(self.addr.add(offset), nhdr.n_descsz as usize);
+                    offset += nhdr.n_descsz as usize;
+                    align(alignment, &mut offset);
+
+                    if nhdr.n_type as u32 == NT_GNU_BUILD_ID {
+                        return Some(SharedLibraryId::GnuBuildId(value.to_vec()));
+                    }
+                }
+            }
+        }
+
         None
     }
 
     #[inline]
     fn segments(&self) -> Self::SegmentIter {
-        SegmentIter { inner: self.headers.iter() }
+        SegmentIter {
+            inner: self.headers.iter(),
+        }
     }
 
     #[inline]
@@ -186,12 +269,14 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
 
     #[inline]
     fn each<F, C>(f: F)
-        where F: FnMut(&Self) -> C,
-              C: Into<IterationControl>
+    where
+        F: FnMut(&Self) -> C,
+        C: Into<IterationControl>,
     {
         let mut state = IterState {
             f: f,
             panic: None,
+            idx: 0,
         };
 
         unsafe {
@@ -206,13 +291,18 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
 
 impl<'a> fmt::Debug for SharedLibrary<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SharedLibrary {{ size: {:?}, addr: {:?}, ", self.size, self.addr)?;
-        write!(f, "name: {:?}, headers: [",  self.name)?;
+        write!(
+            f,
+            "SharedLibrary {{ size: {:?}, addr: {:?}, ",
+            self.size, self.addr
+        )?;
+        write!(f, "name: {:?}, headers: [", self.name)?;
 
         // Debug does not usually have a trailing comma in the list,
         // last element must be formatted separately.
         let l = self.headers.len();
-        self.headers[..(l - 1)].into_iter()
+        self.headers[..(l - 1)]
+            .into_iter()
             .map(|phdr| write!(f, "{:?}, ", &DebugPhdr(phdr)))
             .collect::<fmt::Result>()?;
 
@@ -245,14 +335,15 @@ impl<'a> fmt::Debug for DebugPhdr<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::{IterationControl, Segment, SharedLibrary};
     use linux;
-    use super::super::{IterationControl, SharedLibrary, Segment};
 
     #[test]
     fn have_libc() {
         let mut found_libc = false;
         linux::SharedLibrary::each(|info| {
-            found_libc |= info.name
+            found_libc |= info
+                .name
                 .to_bytes()
                 .split(|c| *c == b'.' || *c == b'/')
                 .find(|s| s == b"libc")
@@ -284,9 +375,52 @@ mod tests {
 
     #[test]
     fn get_name() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let mut names = vec![];
         linux::SharedLibrary::each(|shlib| {
             println!("{:?}", shlib);
-            let _ = shlib.name();
+            let name = OsStr::from_bytes(shlib.name().to_bytes());
+            if name != OsStr::new("") {
+                names.push(name.to_str().unwrap().to_string());
+            }
+        });
+
+        assert!(names[0].contains("/findshlibs"));
+        assert!(names.iter().any(|x| x.contains("libc.so")));
+    }
+
+    #[test]
+    fn get_id() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        use std::path::Path;
+        use std::process::Command;
+
+        linux::SharedLibrary::each(|shlib| {
+            let name = OsStr::from_bytes(shlib.name().to_bytes());
+            let id = shlib.id();
+            if id.is_none() {
+                println!("no id found for {:?}", name);
+                return;
+            }
+            let path: &Path = name.as_ref();
+            if !path.is_absolute() {
+                return;
+            }
+            let gnu_build_id = id.unwrap().to_string();
+            let readelf = Command::new("readelf")
+                .arg("-n")
+                .arg(path)
+                .output()
+                .unwrap();
+            for line in String::from_utf8(readelf.stdout).unwrap().lines() {
+                if let Some(index) = line.find("Build ID: ") {
+                    let readelf_build_id = line[index + 9..].trim();
+                    assert_eq!(readelf_build_id, gnu_build_id);
+                }
+            }
+            println!("{}: {}", path.display(), gnu_build_id);
         });
     }
 


### PR DESCRIPTION
For ELF special handling must be implemented for the main executable
which does not have a name that can be discovered.  This implementation
now uses `env::current_exe` to handle this.  Additionally this now
implements `id()` by loading the ELF binary referenced by a shared
library reference to discover the embedded gnu build id.

This does change behavior quite a bit and the elf code path has been
feature flagged in case developers are not interested in ID handling
which is primarily useful for server side symbolication.

This also removes `Clone` and `Copy` from the shared library trait
on linux. Copy is no longer possible with this implementation and
Clone is not implemented for macos.  This now makes this consistent.

This fixes #31 and #28. I understand that both of those are somewhat
considered outside the scope of this crate but it seems weird to me to
wrap the crate in another crate as users (for at least quite a range of use
cases) are interested in the values of both these attributes.