### PR TITLE
Expose OsStr instead of CStr from API

### DIFF
--- a/examples/list_segments.rs
+++ b/examples/list_segments.rs
@@ -9,7 +9,7 @@ fn main() {
             println!(
                 "    {}: segment {}",
                 seg.actual_virtual_memory_address(shlib),
-                seg.name().to_string_lossy()
+                seg.name()
             );
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ extern crate lazy_static;
 #[cfg(target_os = "linux")]
 extern crate libc;
 
-use std::ffi::CStr;
+use std::ffi::OsStr;
 use std::fmt::{self, Debug};
 use std::ptr;
 
@@ -203,7 +203,7 @@ pub trait Segment: Sized + Debug {
     type SharedLibrary: SharedLibrary<Segment = Self>;
 
     /// Get this segment's name.
-    fn name(&self) -> &CStr;
+    fn name(&self) -> &OsStr;
 
     /// Returns `true` if this is a code segment.
     #[inline]
@@ -310,7 +310,7 @@ pub trait SharedLibrary: Sized + Debug {
     type SegmentIter: Debug + Iterator<Item = Self::Segment>;
 
     /// Get the name of this shared library.
-    fn name(&self) -> &CStr;
+    fn name(&self) -> &OsStr;
 
     /// Get the debug-id of this shared library if available.
     fn id(&self) -> Option<SharedLibraryId>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!         for seg in shlib.segments() {
 //!             println!("    {}: segment {}",
 //!                      seg.actual_virtual_memory_address(shlib),
-//!                      seg.name().to_string_lossy());
+//!                      seg.name());
 //!         }
 //!     });
 //! }
@@ -203,7 +203,7 @@ pub trait Segment: Sized + Debug {
     type SharedLibrary: SharedLibrary<Segment = Self>;
 
     /// Get this segment's name.
-    fn name(&self) -> &OsStr;
+    fn name(&self) -> &str;
 
     /// Returns `true` if this is a code segment.
     #[inline]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -47,23 +47,23 @@ pub struct Segment<'a> {
 impl<'a> SegmentTrait for Segment<'a> {
     type SharedLibrary = ::linux::SharedLibrary<'a>;
 
-    fn name(&self) -> &OsStr {
+    fn name(&self) -> &str {
         unsafe {
             match self.phdr.as_ref().unwrap().p_type {
-                libc::PT_NULL => OsStr::from_bytes(b"NULL"),
-                libc::PT_LOAD => OsStr::from_bytes(b"LOAD"),
-                libc::PT_DYNAMIC => OsStr::from_bytes(b"DYNAMIC"),
-                libc::PT_INTERP => OsStr::from_bytes(b"INTERP"),
-                libc::PT_NOTE => OsStr::from_bytes(b"NOTE"),
-                libc::PT_SHLIB => OsStr::from_bytes(b"SHLI"),
-                libc::PT_PHDR => OsStr::from_bytes(b"PHDR"),
-                libc::PT_TLS => OsStr::from_bytes(b"TLS"),
-                libc::PT_NUM => OsStr::from_bytes(b"NUM"),
-                libc::PT_LOOS => OsStr::from_bytes(b"LOOS"),
-                libc::PT_GNU_EH_FRAME => OsStr::from_bytes(b"GNU_EH_FRAME"),
-                libc::PT_GNU_STACK => OsStr::from_bytes(b"GNU_STACK"),
-                libc::PT_GNU_RELRO => OsStr::from_bytes(b"GNU_RELRO"),
-                _ => OsStr::from_bytes(b"(unknown segment type)"),
+                libc::PT_NULL => "NULL",
+                libc::PT_LOAD => "LOAD",
+                libc::PT_DYNAMIC => "DYNAMIC",
+                libc::PT_INTERP => "INTERP",
+                libc::PT_NOTE => "NOTE",
+                libc::PT_SHLIB => "SHLI",
+                libc::PT_PHDR => "PHDR",
+                libc::PT_TLS => "TLS",
+                libc::PT_NUM => "NUM",
+                libc::PT_LOOS => "LOOS",
+                libc::PT_GNU_EH_FRAME => "GNU_EH_FRAME",
+                libc::PT_GNU_STACK => "GNU_STACK",
+                libc::PT_GNU_RELRO => "GNU_RELRO",
+                _ => "(unknown segment type)",
             }
         }
     }
@@ -424,7 +424,6 @@ mod tests {
 
     #[test]
     fn have_load_segment() {
-        use std::os::unix::ffi::OsStrExt;
         linux::SharedLibrary::each(|shlib| {
             println!("shlib = {:?}", shlib.name());
 
@@ -432,7 +431,7 @@ mod tests {
             for seg in shlib.segments() {
                 println!("    segment = {:?}", seg.name());
 
-                found_load |= seg.name().as_bytes() == b"LOAD";
+                found_load |= seg.name() == "LOAD";
             }
             assert!(found_load);
         });

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -377,7 +377,6 @@ mod tests {
     #[test]
     fn get_name() {
         use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
         let mut names = vec![];
         linux::SharedLibrary::each(|shlib| {
             println!("{:?}", shlib);
@@ -393,8 +392,6 @@ mod tests {
 
     #[test]
     fn get_id() {
-        use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
         use std::path::Path;
         use std::process::Command;
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -37,12 +37,12 @@ impl<'a> SegmentTrait for Segment<'a> {
     type SharedLibrary = ::macos::SharedLibrary<'a>;
 
     #[inline]
-    fn name(&self) -> &OsStr {
+    fn name(&self) -> &str {
         let cstr = match *self {
             Segment::Segment32(seg) => unsafe { CStr::from_ptr(seg.segname.as_ptr()) },
             Segment::Segment64(seg) => unsafe { CStr::from_ptr(seg.segname.as_ptr()) },
         };
-        OsStr::from_bytes(cstr.to_bytes())
+        cstr.to_str().unwrap_or("")
     }
 
     #[inline]
@@ -330,7 +330,6 @@ mod tests {
 
     #[test]
     fn have_text_or_pagezero() {
-        use std::os::unix::ffi::OsStrExt;
         macos::SharedLibrary::each(|shlib| {
             println!("shlib = {:?}", shlib.name());
 
@@ -338,8 +337,8 @@ mod tests {
             for seg in shlib.segments() {
                 println!("    segment = {:?}", seg.name());
 
-                found_text_or_pagezero |= seg.name().as_bytes() == b"__TEXT";
-                found_text_or_pagezero |= seg.name().as_bytes() == b"__PAGEZERO";
+                found_text_or_pagezero |= seg.name() == "__TEXT";
+                found_text_or_pagezero |= seg.name() == "__PAGEZERO";
             }
             assert!(found_text_or_pagezero);
         });

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -42,7 +42,7 @@ impl<'a> SegmentTrait for Segment<'a> {
             Segment::Segment32(seg) => unsafe { CStr::from_ptr(seg.segname.as_ptr()) },
             Segment::Segment64(seg) => unsafe { CStr::from_ptr(seg.segname.as_ptr()) },
         };
-        cstr.to_str().unwrap_or("")
+        cstr.to_str().unwrap_or("(invalid segment name)")
     }
 
     #[inline]

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -19,7 +19,7 @@ impl<'a> SegmentTrait for Segment<'a> {
     type SharedLibrary = ::unsupported::SharedLibrary<'a>;
 
     #[inline]
-    fn name(&self) -> &OsStr {
+    fn name(&self) -> &str {
         unreachable!()
     }
 

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -5,7 +5,7 @@ use super::Segment as SegmentTrait;
 use super::SharedLibrary as SharedLibraryTrait;
 use super::{Bias, IterationControl, SharedLibraryId, Svma};
 
-use std::ffi::CStr;
+use std::ffi::OsStr;
 use std::marker::PhantomData;
 use std::usize;
 
@@ -19,7 +19,7 @@ impl<'a> SegmentTrait for Segment<'a> {
     type SharedLibrary = ::unsupported::SharedLibrary<'a>;
 
     #[inline]
-    fn name(&self) -> &CStr {
+    fn name(&self) -> &OsStr {
         unreachable!()
     }
 
@@ -60,7 +60,7 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
     type SegmentIter = SegmentIter<'a>;
 
     #[inline]
-    fn name(&self) -> &CStr {
+    fn name(&self) -> &OsStr {
         unreachable!()
     }
 


### PR DESCRIPTION
This changes the public API of findshlibs to return `OsStr` instead of `CStr`. The reason for this is that I started working on windows support and there the CStr is tricky to deal with. There are two sources of strings that would be exposed (from the PE which has UTF-16 and PDB which has some UTF-8 strings) and neither fit into `CStr`.