### PR TITLE
Added address and size to the shared library trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ extern crate libc;
 use std::ffi::CStr;
 use std::fmt::{self, Debug};
 use std::ptr;
+use std::usize;
 
 pub mod unsupported;
 
@@ -319,17 +320,23 @@ pub trait SharedLibrary: Sized + Debug {
     /// Returns the address of where the library is loaded.
     ///
     /// This typically is the stated virtual memory address of the first
-    /// code segment.
-    fn stated_virtual_memory_address(&self) -> Svma {
+    /// code segment but not always.  We follow the breakpad semantics for
+    /// what is considered the load address here so that this information
+    /// can be used to drive server side symbolication systems which are
+    /// generally working with the breakpad definition of what the image
+    /// load address is.
+    fn load_addr(&self) -> Svma {
         self.segments()
             .find(|x| x.is_code())
             .map(|x| x.stated_virtual_memory_address())
-            .unwrap_or_else(|| Svma(ptr::null()))
+            .unwrap_or_else(|| Svma(usize::MAX as _))
     }
 
     /// Returns the size of the image.
     ///
-    /// This typically is the size of the executable code segment.
+    /// This typically is the size of the executable code segment.  This is
+    /// normally used by server side symbolication systems to determine when
+    /// an IP no longer falls into an image.
     fn len(&self) -> usize {
         self.segments()
             .skip_while(|x| !x.is_code())

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -10,6 +10,7 @@ use std::env::current_exe;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::isize;
+use std::usize;
 use std::marker::PhantomData;
 use std::mem;
 use std::os::unix::ffi::OsStringExt;
@@ -41,6 +42,18 @@ struct Nhdr32 {
 pub struct Segment<'a> {
     phdr: *const Phdr,
     shlib: PhantomData<&'a ::linux::SharedLibrary<'a>>,
+}
+
+impl<'a> Segment<'a> {
+    fn is_load(&self) -> bool {
+        unsafe {
+            let hdr = self.phdr.as_ref().unwrap();
+            match hdr.p_type {
+                libc::PT_LOAD => true,
+                _ => false,
+            }
+        }
+    }
 }
 
 impl<'a> SegmentTrait for Segment<'a> {
@@ -265,6 +278,21 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
     fn virtual_memory_bias(&self) -> Bias {
         assert!((self.addr as usize) < (isize::MAX as usize));
         Bias(self.addr as usize as isize)
+    }
+
+    fn load_addr(&self) -> Svma {
+        self.segments()
+            .find(|x| x.is_load())
+            .map(|x| x.stated_virtual_memory_address())
+            .unwrap_or_else(|| Svma(usize::MAX as _))
+    }
+
+    fn len(&self) -> usize {
+        self.segments()
+            .skip_while(|x| !x.is_load())
+            .take_while(|x| x.is_load())
+            .map(|x| x.len())
+            .sum()
     }
 
     #[inline]


### PR DESCRIPTION
This is useful for server side symbolication as this information is typically used by tools like breakpad to figure out if an address is in the range of the image.