### PR TITLE
Fix address/bias on 32-bit systems

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -11,14 +11,13 @@ use std::borrow::Cow;
 use std::env::current_exe;
 use std::ffi::{CStr, CString, OsStr};
 use std::fmt;
-use std::isize;
-use std::usize;
 use std::marker::PhantomData;
 use std::mem;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::ffi::OsStringExt;
 use std::panic;
 use std::slice;
+use std::usize;
 
 #[cfg(target_pointer_width = "32")]
 type Phdr = libc::Elf32_Phdr;
@@ -273,8 +272,7 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
 
     #[inline]
     fn virtual_memory_bias(&self) -> Bias {
-        assert!((self.addr as usize) < (isize::MAX as usize));
-        Bias(self.addr as usize as isize)
+        Bias(self.addr as usize)
     }
 
     fn load_addr(&self) -> Svma {
@@ -360,8 +358,8 @@ impl<'a> fmt::Debug for DebugPhdr<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{IterationControl, Segment, SharedLibrary};
     use crate::linux;
+    use crate::{IterationControl, Segment, SharedLibrary};
 
     #[test]
     fn have_libc() {

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -73,10 +73,10 @@ impl<'a> SegmentTrait for Segment<'a> {
     #[inline]
     fn stated_virtual_memory_address(&self) -> Svma {
         match *self {
-            Segment::Segment32(seg) => Svma(seg.vmaddr as usize as *const u8),
+            Segment::Segment32(seg) => Svma(seg.vmaddr as usize),
             Segment::Segment64(seg) => {
                 assert!(seg.vmaddr <= (usize::MAX as u64));
-                Svma(seg.vmaddr as usize as *const u8)
+                Svma(seg.vmaddr as usize)
             }
         }
     }
@@ -199,7 +199,7 @@ impl<'a> MachHeader<'a> {
 /// `<mach-o/dyld.h>` header.
 pub struct SharedLibrary<'a> {
     header: MachHeader<'a>,
-    slide: isize,
+    slide: usize,
     name: &'a CStr,
 }
 
@@ -213,7 +213,7 @@ impl<'a> fmt::Debug for SharedLibrary<'a> {
 }
 
 impl<'a> SharedLibrary<'a> {
-    fn new(header: MachHeader<'a>, slide: isize, name: &'a CStr) -> Self {
+    fn new(header: MachHeader<'a>, slide: usize, name: &'a CStr) -> Self {
         SharedLibrary {
             header: header,
             slide: slide,
@@ -296,7 +296,7 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
                 );
 
                 let name = unsafe { CStr::from_ptr(name) };
-                let shlib = SharedLibrary::new(header, slide, name);
+                let shlib = SharedLibrary::new(header, slide as usize, name);
 
                 match f(&shlib).into() {
                     IterationControl::Break => break,


### PR DESCRIPTION
More generally, any platform where library addresses can be in the
"negative" part of the address space (ie, address MSB is 1).

This consistently uses `usize` for both `Bias` and
addresses (`Avma`, `Svma`). This assumes `Bias` is always positive, and
can be very large.

Converting `Avma`/`Svma` to usize makes the address
arithmetic easier, as it avoids `ptr::offset`, which can take both
positive and negative offsets, which means it can't offset by more than
half the address space. It is also undefined for general `*mut u8`
pointer arithmetic ("Both the starting and resulting pointer must
be either in bounds or one byte past the end of the same allocated
object" is not met, nor is "The offset being in bounds cannot rely on
"wrapping around" the address space. That is, the infinite-precision
sum, in bytes must fit in a usize").

Fixes issue #47