### PR TITLE
Use memory sizes and offsets, not file sizes and file offsets on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.31.0
+- 1.34.0
 cache: cargo
 
 addons:


### PR DESCRIPTION
In the `SharedLibrary::id` method on Linux, we were mistakenly using file sizes
and offsets when searching through the notes structures in the PT_NOTE
segment. This corrects that issue to use the fields in phdr et al that are
explicitly for memory offsets and sizes.

Fixes #50

cc @JakubOnderka -- I haven't actually been able to reproduce #50 on my machine, can you test this out and verify whether it fixes the issue?