### PR TITLE
Bump to version 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "findshlibs"
 readme = "./README.md"
 repository = "https://github.com/gimli-rs/findshlibs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 
 [badges.coveralls]


### PR DESCRIPTION
There were some minor public API changes to types, so this isn't a 0.6.1 release.

Fixes #53