### PR TITLE
Remove bogus alignment assertion

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -112,9 +112,7 @@ impl<'a> Segment<'a> {
             let nhdr = try_split_at(&mut data, nhdr_size)?;
             let nhdr = (nhdr.as_ptr() as *const Nhdr).as_ref().unwrap();
 
-            // No need to `align_up` after the `Nhdr`.
-            debug_assert_eq!(nhdr_size % alignment, 0);
-
+            // No need to `align_up` after the `Nhdr`
             // It is followed by a name of size `n_namesz`.
             let name_size = nhdr.n_namesz as usize;
             let name = try_split_at(&mut data, name_size)?;


### PR DESCRIPTION
There doesn't appear to be any guarantee that the size of an `Nhdr` will
be an even multiple of the `Phdr` segment alignment field (`p_align`).

I'm happy to be corrected on this, but from my own reading of `man 5 elf` I can't
see why this alignment would be anything more than a coincidence where the
segment alignment happened to be 4.

The manpage also seems to suggest that the `descriptor` following the `name` field
should *always* be aligned on 4 (it makes no mention of the `Phdr` alignment property).

Is this something the manpage gets wrong? (I notice the comment that says `readelf` also contradicts the manpage)

