### PR TITLE
on iOS with XCode set to debug mode, _dyld_get_image_vmaddr_slide will always return 0 (on some library)

### DIFF
--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -287,10 +287,6 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
 
             if let Some(header) = unsafe { MachHeader::from_header_ptr(header) } {
                 assert!(
-                    slide != 0,
-                    "If we have a header pointer, slide should be valid"
-                );
-                assert!(
                     !name.is_null(),
                     "If we have a header pointer, name should be valid"
                 );


### PR DESCRIPTION
Fix #70 