### PR TITLE
Update dependencies, clean up code and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "findshlibs"
-version = "0.10.1"
+version = "0.10.2"
 description = "Find the set of shared libraries loaded in the current process with a cross platform API"
 documentation = "https://docs.rs/findshlibs"
 edition = "2018"
@@ -10,7 +10,7 @@ readme = "./README.md"
 repository = "https://github.com/gimli-rs/findshlibs"
 
 [dependencies]
-libc = "0.2.98"
+libc = "0.2.104"
 
 [build-dependencies]
 # Only needed for Android, but cannot be target dependent

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -27,19 +27,6 @@ type Phdr = libc::Elf32_Phdr;
 type Phdr = libc::Elf64_Phdr;
 
 const NT_GNU_BUILD_ID: u32 = 3;
-const PT_NULL: u32 = 0;
-const PT_LOAD: u32 = 1;
-const PT_DYNAMIC: u32 = 2;
-const PT_INTERP: u32 = 3;
-const PT_NOTE: u32 = 4;
-const PT_SHLIB: u32 = 5;
-const PT_PHDR: u32 = 6;
-const PT_TLS: u32 = 7;
-const PT_NUM: u32 = 8;
-const PT_LOOS: u32 = 0x60000000;
-const PT_GNU_EH_FRAME: u32 = 0x6474e550;
-const PT_GNU_STACK: u32 = 0x6474e551;
-const PT_GNU_RELRO: u32 = 0x6474e552;
 
 // Normally we would use `Elf32_Nhdr` on 32-bit platforms and `Elf64_Nhdr` on
 // 64-bit platforms. However, in practice it seems that only `Elf32_Nhdr` is
@@ -72,7 +59,7 @@ impl<'a> Segment<'a> {
     }
 
     fn is_note(&self) -> bool {
-        self.phdr().p_type == PT_NOTE
+        self.phdr().p_type == libc::PT_NOTE
     }
 
     /// Parse the contents of a `PT_NOTE` segment.
@@ -157,19 +144,17 @@ impl<'a> SegmentTrait for Segment<'a> {
     fn name(&self) -> &str {
         unsafe {
             match self.phdr.as_ref().unwrap().p_type {
-                PT_NULL => "NULL",
-                PT_LOAD => "LOAD",
-                PT_DYNAMIC => "DYNAMIC",
-                PT_INTERP => "INTERP",
-                PT_NOTE => "NOTE",
-                PT_SHLIB => "SHLI",
-                PT_PHDR => "PHDR",
-                PT_TLS => "TLS",
-                PT_NUM => "NUM",
-                PT_LOOS => "LOOS",
-                PT_GNU_EH_FRAME => "GNU_EH_FRAME",
-                PT_GNU_STACK => "GNU_STACK",
-                PT_GNU_RELRO => "GNU_RELRO",
+                libc::PT_NULL => "NULL",
+                libc::PT_LOAD => "LOAD",
+                libc::PT_DYNAMIC => "DYNAMIC",
+                libc::PT_INTERP => "INTERP",
+                libc::PT_NOTE => "NOTE",
+                libc::PT_SHLIB => "SHLIB",
+                libc::PT_PHDR => "PHDR",
+                libc::PT_TLS => "TLS",
+                libc::PT_GNU_EH_FRAME => "GNU_EH_FRAME",
+                libc::PT_GNU_STACK => "GNU_STACK",
+                libc::PT_GNU_RELRO => "GNU_RELRO",
                 _ => "(unknown segment type)",
             }
         }
@@ -179,12 +164,12 @@ impl<'a> SegmentTrait for Segment<'a> {
     fn is_code(&self) -> bool {
         let hdr = self.phdr();
         // 0x1 is PT_X for executable
-        hdr.p_type == PT_LOAD && (hdr.p_flags & 0x1) != 0
+        hdr.p_type == libc::PT_LOAD && (hdr.p_flags & 0x1) != 0
     }
 
     #[inline]
     fn is_load(&self) -> bool {
-        self.phdr().p_type == PT_LOAD
+        self.phdr().p_type == libc::PT_LOAD
     }
 
     #[inline]

--- a/src/macos/bindings.h
+++ b/src/macos/bindings.h
@@ -1,1 +1,0 @@
-#include <mach-o/dyld.h>

--- a/src/macos/bindings.rs
+++ b/src/macos/bindings.rs
@@ -1,6 +1,0 @@
-#![allow(non_snake_case)]
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
-#![allow(clippy::unreadable_literal)]
-
-include!(concat!(env!("OUT_DIR"), "/macos_bindings.rs"));


### PR DESCRIPTION
Since [this PR](https://github.com/rust-lang/libc/pull/2440), ELF program header definitions has been added for android platform, we can delete them from `findshlibs` and just use libc's as before.

This PR also removes some legacy `bindgen` code for macOS and bumps version to `0.10.2`. 