### PR TITLE
deps: Move from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,13 @@ cc = "1.0.67"
 lazy_static = "1.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.9", features = ["psapi", "memoryapi", "libloaderapi", "processthreadsapi"] }
+windows-sys = { version = "0.45", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_System_ProcessStatus",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_SystemInformation",
+] }


### PR DESCRIPTION
`winapi` is in maintenance mode and the new blessed way to access Windows APIs are the `windows`
and `windows-sys` crates. I don't think any types of `winapi` were exposed in the public API so
I used `windows-sys` since it has much faster compile times.
