### PR TITLE
fix: add missing `wrapping_add`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ pub trait Segment: Sized + Debug {
     fn actual_virtual_memory_address(&self, shlib: &Self::SharedLibrary) -> Avma {
         let svma = self.stated_virtual_memory_address();
         let bias = shlib.virtual_memory_bias();
-        Avma(svma.0 + bias.0)
+        Avma(svma.0.wrapping_add(bias.0))
     }
 
     /// Does this segment contain the given address?


### PR DESCRIPTION
close #77
We ran into the same problem with issue #77 . 
I found the same logic as [lib.rs:261](https://github.com/gimli-rs/findshlibs/blob/0.10.2/src/lib.rs#L261) in [mod.rs](https://github.com/gimli-rs/findshlibs/blob/master/src/linux/mod.rs#L57), but using `wrapping_add`, which I'm guessing may have been missed in [lib.rs:261](https://github.com/gimli-rs/findshlibs/blob/0.10.2/src/lib.rs#L261).
Can you please help to review that my changes are correct? I am not very familiar with this field.